### PR TITLE
turned on multithreading for psiblast

### DIFF
--- a/cmd/mica-psisearch/main.go
+++ b/cmd/mica-psisearch/main.go
@@ -173,6 +173,7 @@ func blastFine(
 	// defined flags.
 	flags := []string{"-db", path.Join(blastFineDir, mica.FileBlastFine),
 		"-num_iterations", s(flagIters),
+		"-num_threads", s(flagGoMaxProcs),
 		"-dbsize", su(db.BlastDBSize)}
 	flags = append(flags, blastArgs...)
 
@@ -253,6 +254,7 @@ func blastCoarse(
 	db *mica.DB, stdin *bytes.Reader, stdout *bytes.Buffer) error {
 	flags := []string{"-db", path.Join(db.Path, mica.FileBlastCoarse),
 		"-outfmt", "5", "-num_iterations", s(flagIters),
+		"-num_threads", s(flagGoMaxProcs),
 		"-dbsize", su(db.BlastDBSize)}
 
 	cmd := exec.Command(flagPsiBlast, flags...)


### PR DESCRIPTION
Previously, when mica-psisearch called psiblast it neglected to include the -num_threads parameter.
This meant that mica-psisearch had significantly worse performance than vanilla psiblast on machines with multiple threads.
In this change I remedied that by copying the line of code that sets num_threads from mica-psearch to mica-psisearch.